### PR TITLE
测试失败修复

### DIFF
--- a/test/lib/casServer.js
+++ b/test/lib/casServer.js
@@ -243,7 +243,7 @@ module.exports = (app, options) => {
     if (this.query && this.query.service) {
       const pgtId = uuid.v4();
       tgts[pgtId] = initTgt();
-      const st = uuid.v4();
+      const st = 'ST-'+uuid.v4();
       tgts[pgtId].st[st] = initTicket(this.query.service);
       const path = decodeURIComponent(this.query.service);
       const uri = url.parse(path, true);


### PR DESCRIPTION
测试使用的CasServer生成的 Service Ticket 直接使用 UUID，格式不符合 lib/validate 中的验证规则: 以 ST- 开头，导致 getProxyTicket.test.js 等测试用例失败，通过为测试生成的 Service Ticket 添加 ST- 前缀解决这个问题，测试全部通过